### PR TITLE
Clean vcpkg artifacts on solution clean

### DIFF
--- a/src/vcpkg.props
+++ b/src/vcpkg.props
@@ -61,6 +61,14 @@
     <Exec Command="pwsh.exe -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)VcpkgPortOverlay\CreatePortOverlay.ps1&quot; -StampFile &quot;$(MSBuildThisFileDirectory)VcpkgPortOverlay\.created&quot;" />
   </Target>
 
+  <!-- Visual Studio "Clean Solution" only clears project build outputs. vcpkg artifacts
+       live under src\vcpkg_installed and are not removed unless we clean them explicitly.
+       Removing the overlay stamp forces regeneration of overlay ports on the next build. -->
+  <Target Name="CleanVcpkg" AfterTargets="Clean">
+    <RemoveDir Directories="$(VcpkgInstalledDir)" />
+    <Delete Files="$(MSBuildThisFileDirectory)VcpkgPortOverlay\.created" />
+  </Target>
+
   <Target Name="EnsureNoTripletMismatch"
           BeforeTargets="PrepareForBuild"
           Condition="'$(_IsBuildingSln)' != 'true'" >


### PR DESCRIPTION
## 📖 Description
Add a `CleanVcpkg` target in `src\vcpkg.props` so Visual Studio **Clean Solution** removes repository-local vcpkg artifacts.

The target:
- Deletes `$(VcpkgInstalledDir)` (`src\vcpkg_installed\`)
- Deletes `src\VcpkgPortOverlay\.created` so overlay ports regenerate on next build

Also adds an XML comment block explaining why this cleanup is necessary.

## 🔗 References
Related to microsoft/winget-cli#6338

## 🔍 Validation
Manual local verification of MSBuild target wiring only.

## ✅ Checklist
- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [ ] Updated [Release Notes](../doc/ReleaseNotes.md) (if applicable)
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
- [x] Bug fix
- [ ] Feature
- [ ] Task

---
Assisted-by: GitHub Copilot